### PR TITLE
expose database driver

### DIFF
--- a/lib/src/dartonic_base.dart
+++ b/lib/src/dartonic_base.dart
@@ -2,11 +2,11 @@ import 'drivers/driver.dart';
 import 'query_builder/database_facade.dart';
 import 'types/types.dart';
 
-class Dartonic {
+class Dartonic<T extends DatabaseDriver> {
   static Dartonic? _instance;
   final String uri;
   final Map<String, TableSchema> _schemas;
-  late final DatabaseDriver _driver;
+  late final T _driver;
   final List<PgEnumDefinition> _enums;
 
   Dartonic._internal(this.uri, List<TableSchema> schemas, this._enums)
@@ -21,6 +21,7 @@ class Dartonic {
     return _instance!;
   }
 
+  T get driver => _driver;
   DatabaseFacade get instance => DatabaseFacade(_driver, _schemas);
   DatabaseFacade get I => DatabaseFacade(_driver, _schemas);
 


### PR DESCRIPTION
Allows us to create our own migrations, since this package seems to touch that a little bit by creating tables if they don't exist, but not updating them when we change tables.